### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -18,8 +18,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  # end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,4 @@
 class Order < ApplicationRecord
-  # belongs_to :user
-  # belongs_to :item
+  belongs_to :user
+  belongs_to :item
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <% if @items.any? %>
   <% @items.each do |item| %>
     <li class='list'>
-      <%= link_to "#" do %>
+      <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '300x300'), class: 'item-image' if item.image.attached? %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,64 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
-    <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+    <%= image_tag @item.image.variant(resize: '300x300'), class: 'item-image' if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# if @item.sold_out? %>
+       <div class="sold-out">
+         <span>Sold Out!!</span>
+       </div>
+      <%# end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee_burden.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+  <% if user_signed_in? %>
+  <% if current_user.id == @item.user_id %>
+    <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%= link_to "削除",  "/items/#{@item.id}", data: {turbo_method: :delete}, class:"item-destroy" %>
+  <% else %>
+ <%# if @item.not_sold_out? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+  <%# end %>
+<% end %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -79,6 +76,7 @@
       </div>
     </div>
   </div>
+  <% end %>
   <%# /商品の概要 %>
 
   <div class="comment-box">
@@ -104,7 +102,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href= "#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
     <%= link_to "削除",  "/items/#{@item.id}", data: {turbo_method: :delete}, class:"item-destroy" %>
   <% else %>
  <%# if @item.not_sold_out? %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
   <%# end %>
 <% end %>
     <div class="item-explain-box">


### PR DESCRIPTION
# What
商品の詳細表示機能を作成しました。

# Why
フリマアプリ作成のため。

# 補足
「ログイン状態の場合でも、売却済みの商品には、『商品の編集』『削除』『購入画面に進む』ボタンが表示されないこと」
「売却済みの商品は、画像上に『sold out』の文字が表示されること」という機能ですが、商品購入機能実装後に実装いたします。

Gyazo添付いたします。
ご確認よろしくお願いします。

・ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/1250e64f4b080adf06e82df3dd2d0cef

・ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/9c46779bdd3e96cede43824f20874481

・ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/180e7be4697814f92afc1178f0cdffae